### PR TITLE
Fix missing test references

### DIFF
--- a/include/boost/certify/detail/keystore_windows.ipp
+++ b/include/boost/certify/detail/keystore_windows.ipp
@@ -96,7 +96,7 @@ BOOST_CERTIFY_DECL std::unique_ptr<::CERT_CONTEXT const, cert_context_deleter>
     if (!CertAddEncodedCertificateToStore(store.get(),
                                           X509_ASN_ENCODING,
                                           buffer.data(),
-                                          buffer.size(),
+                                          static_cast<DWORD>(buffer.size()),
                                           CERT_STORE_ADD_ALWAYS,
                                           &leaf_cert))
         return nullptr;
@@ -110,7 +110,7 @@ BOOST_CERTIFY_DECL std::unique_ptr<::CERT_CONTEXT const, cert_context_deleter>
         if (!CertAddEncodedCertificateToStore(store.get(),
                                               X509_ASN_ENCODING,
                                               buffer.data(),
-                                              buffer.size(),
+                                              static_cast<DWORD>(buffer.size()),
                                               CERT_STORE_ADD_ALWAYS,
                                               nullptr))
             return nullptr;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,5 +11,5 @@ function (certify_verify_add_test test_file)
              COMMAND ${target_name})
 endfunction(certify_verify_add_test)
 
-certify_verify_add_test(rfc2818_verification_success.cpp)
-certify_verify_add_test(rfc2818_verification_fail.cpp)
+certify_verify_add_test(https_verification_success.cpp)
+certify_verify_add_test(https_verification_fail.cpp)


### PR DESCRIPTION
Update build system to reference https verification tests instead of rfc2818 verification tests.

Additionally, fix some implicit casts to prevent warnings during build on Win32.